### PR TITLE
Update urls to use https to prevent modern browsers blocking content loading

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -43,7 +43,7 @@ GoogleMapsLoader.load(function(google) {
 });
 
 // const dbPath = process.env.NODE_ENV == 'production' ? 'https://higheredindex-backend.newamerica.org/api/' : 'http://localhost:3000/api/';
-const dbPath = 'http://higheredindex-backend.newamerica.org/api/';
+const dbPath = 'https://higheredindex-backend.newamerica.org/api/';
 
 /*
  * action creators

--- a/src/react_components/pages/ApiDocsPage.js
+++ b/src/react_components/pages/ApiDocsPage.js
@@ -9,11 +9,11 @@ import { fetchDataInfo } from '../../actions'
 import apiDocsSettings from '../../settings/apiDocsSettings.js';
 
 const downloadDataFile = (collection) => {
-   window.open('http://higheredindex-backend.newamerica.org/api/download_data/' + collection);
+   window.open('https://higheredindex-backend.newamerica.org/api/download_data/' + collection);
 }
 
 const downloadCodebookFile = (type) => {
-   window.open('http://higheredindex-backend.newamerica.org/api/download_codebook/' + type);
+   window.open('https://higheredindex-backend.newamerica.org/api/download_codebook/' + type);
 }
 
 class ApiDocsPage extends React.Component {
@@ -54,7 +54,7 @@ class ApiDocsPage extends React.Component {
         <div className="simple-page__overlay"></div>
         <div className="simple-page__content">
           <h5 className="simple-page__title">API Documentation</h5>
-          <p className="download-home-page__description">Endpoint URL: <strong>http://higheredindex-backend.newamerica.org/api/</strong></p>
+          <p className="download-home-page__description">Endpoint URL: <strong>https://higheredindex-backend.newamerica.org/api/</strong></p>
           <p className="download-home-page__description">Data used on this site are available via the API endpoints listed below. Institution files each contain header information for each school, including the school name and location, sector, and unique identifiers, and other pertinent institutional characteristics. The schools file contains information on graduation and retention rates, transfer rates, cost of attendance, endowments, share of students receiving aid and the average amount of aid received, as well as other miscellaneous data presented in that section. Student files contain information on total enrollment, enrollment by student level and attendance intensity, and enrollment breakdowns by race and nontraditional student factors. Loans files contain information on loan disbursements and recipients for each type of federal loan, repayment rates, and cohort default rates. Grants file contain information on recipients and disbursements of federal grant aid, including Pell grants,  and the share of students receiving Pell and other types of aid. Outcomes files contain information on post-graduation earnings, debt levels.</p>
           <p className="download-home-page__description">State, sector, and national-level data are each based on aggregations of school level data, based on the geographic location of the headquarters of the school. Codebooks include variable names, source materials, and definitions, as well as a detailed explanation of how institution level data were aggregated to the state level.</p>
           <p className="download-home-page__description">Collection options: 'states_grants', 'states_loans', 'states_outcomes', 'states_students', 'states_schools_all', 'states_schools_public4', 'states_schools_public2', 'states_schools_nonprofit', 'states_schools_forprofit', 'inst_grants', 'inst_loans', 'inst_outcomes', 'inst_students', 'inst_schools'</p>

--- a/src/react_components/pages/DownloadHomePage.js
+++ b/src/react_components/pages/DownloadHomePage.js
@@ -10,11 +10,11 @@ import { fetchDataInfo } from '../../actions'
 import sectionSettings from '../../settings/sectionSettings.js';
 
 const downloadDataFile = (collection) => {
-   window.open('http://higheredindex-backend.newamerica.org/api/download_data/' + collection);
+   window.open('https://higheredindex-backend.newamerica.org/api/download_data/' + collection);
 }
 
 const downloadCodebookFile = (type) => {
-   window.open('http://higheredindex-backend.newamerica.org/api/download_codebook/' + type);
+   window.open('https://higheredindex-backend.newamerica.org/api/download_codebook/' + type);
 }
 
 class DownloadHomePage extends React.Component {


### PR DESCRIPTION
Currently, at least Firefox blocks content loading from the backend due to the use of http. Coupled with this change, I have enabled heroku's auto SSL features on the backend app so we can use https, so hopefully this should resolve the errors.